### PR TITLE
Add Qwen3 tool dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,35 @@ export OPENAI_API_KEY="your-api-key-here"
 > - xai
 > - groq
 > - arceeai
+> - qwen3 (via AcidicSoil/codex middleware)
 > - any other provider that is compatible with the OpenAI API
 >
+Using Qwen3 requires running Codex with the Qwen3 LLM and enabling tool calls.
+Below is a minimal example payload for the `/v1/chat/completions` endpoint:
+
+```json
+{
+  "model": "qwen/qwen3-4b",
+  "messages": [{ "role": "user", "content": "What's the weather in Tokyo?" }],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": { "type": "string" },
+            "unit": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+          },
+          "required": ["location"]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto"
+}
+```
 > If you use a provider other than OpenAI, you will need to set the API key for the provider in the config file or in the environment variable as:
 >
 > ```shell

--- a/codex-cli/src/tools/dispatcher.ts
+++ b/codex-cli/src/tools/dispatcher.ts
@@ -1,0 +1,28 @@
+import type { AnyZodObject } from "zod";
+
+import { getWeather, WeatherArgsSchema } from "./weather";
+
+const registry: Record<string, { schema: AnyZodObject; run: (args: unknown) => Promise<string> }> = {
+  get_weather: {
+    schema: WeatherArgsSchema,
+    run: getWeather,
+  },
+};
+
+export async function dispatchToolCall(name: string, argsJson: string): Promise<string> {
+  const tool = registry[name];
+  if (!tool) {
+    throw new Error(`Unknown tool: ${name}`);
+  }
+  let args;
+  try {
+    args = JSON.parse(argsJson);
+  } catch {
+    throw new Error("Arguments must be valid JSON");
+  }
+  const parsed = tool.schema.safeParse(args);
+  if (!parsed.success) {
+    throw new Error("Tool argument validation failed");
+  }
+  return tool.run(parsed.data);
+}

--- a/codex-cli/src/tools/weather.ts
+++ b/codex-cli/src/tools/weather.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const WeatherArgsSchema = z.object({
+  location: z.string(),
+  unit: z.enum(["celsius", "fahrenheit"]).default("celsius"),
+});
+
+export async function getWeather(args: unknown): Promise<string> {
+  const parsed = WeatherArgsSchema.safeParse(args);
+  if (!parsed.success) {
+    throw new Error("Invalid arguments for get_weather");
+  }
+  const { location, unit } = parsed.data;
+  // Placeholder implementation to avoid external requests
+  return `The weather in ${location} is 23\u00b0 ${unit}`;
+}

--- a/codex-cli/tests/tool-dispatcher.test.ts
+++ b/codex-cli/tests/tool-dispatcher.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { dispatchToolCall } from "../src/tools/dispatcher";
+
+describe("dispatchToolCall", () => {
+  it("runs registered tool", async () => {
+    const result = await dispatchToolCall(
+      "get_weather",
+      JSON.stringify({ location: "Tokyo", unit: "celsius" }),
+    );
+    expect(result).toMatch("Tokyo");
+  });
+
+  it("throws on unknown tool", async () => {
+    await expect(
+      dispatchToolCall("unknown", "{}"),
+    ).rejects.toThrow("Unknown tool");
+  });
+});


### PR DESCRIPTION
## Summary
- add tool dispatcher to run validated tools
- implement `get_weather` tool example
- document Qwen3 LLM usage and example API payload
- test dispatcher logic

## Testing
- `pnpm test` *(fails: raw-exec-process-group.test.ts)*
- `cargo test` *(fails: landlock sandbox tests)*

------
https://chatgpt.com/codex/tasks/task_e_684aebf125a48328876b0ae6940d1bcf